### PR TITLE
[#14] Feat: 비밀번호 변경 기능 구현

### DIFF
--- a/src/main/java/com/parentsgowork/server/web/controller/UserController.java
+++ b/src/main/java/com/parentsgowork/server/web/controller/UserController.java
@@ -3,12 +3,15 @@ package com.parentsgowork.server.web.controller;
 import com.parentsgowork.server.apiPayload.ApiResponse;
 import com.parentsgowork.server.service.userService.UserCommandService;
 import com.parentsgowork.server.web.controller.specification.UserSpecification;
+import com.parentsgowork.server.web.dto.UserDTO.UserRequestDTO;
 import com.parentsgowork.server.web.dto.UserDTO.UserResponseDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +22,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController implements UserSpecification {
 
     private final UserCommandService userCommandService;
+
+    @Override
+    @PatchMapping("/password")
+    public ApiResponse<Void> findPassword(@RequestBody @Valid UserRequestDTO.PasswordDTO passwordDTO) {
+        userCommandService.updatePassword(passwordDTO);
+        return ApiResponse.onSuccess();
+    }
 
     @Override
     @PatchMapping("")

--- a/src/main/java/com/parentsgowork/server/web/controller/specification/UserSpecification.java
+++ b/src/main/java/com/parentsgowork/server/web/controller/specification/UserSpecification.java
@@ -1,14 +1,29 @@
 package com.parentsgowork.server.web.controller.specification;
 
 import com.parentsgowork.server.apiPayload.ApiResponse;
+import com.parentsgowork.server.web.dto.UserDTO.UserRequestDTO;
 import com.parentsgowork.server.web.dto.UserDTO.UserResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 public interface UserSpecification {
+
+    @PatchMapping("/password")
+    @Operation(summary = "비밀번호 변경", description = "", security = @SecurityRequirement(name = "tempToken"))
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH4002", description = "❌ 이메일 인증을 완료해주세요.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4002", description = "❌ 이메일 또는 패스워드가 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4004", description = "❌ 탈퇴한 회원입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PWD4001", description = "❌ 비밀번호 확인이 일치하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    ApiResponse<Void> findPassword(@RequestBody @Valid UserRequestDTO.PasswordDTO passwordDTO);
     @PatchMapping("")
     @Operation(summary = "회원 탈퇴 API", description = "사용자가 자신의 계정을 삭제하는 API입니다.")
     @ApiResponses({


### PR DESCRIPTION
## 📝 작업 내용
> 비밀번호 변경 기능 구현

변경하기 전 비밀번호로 로그인하면 "이전 비밀번호로 로그인하려고 합니다." 또는 "비밀번호를 변경한지 n일 지났습니다" 이런 메시지가 출력되게 하고싶은데 다른 기능들 구현 후 후순위로 생각하고 있습니다. (+ 이메일 인증 시 페이지 배경 색상 변경하는 것도 후순위)

## 🔍 테스트 방법
> 회원가입 시 비밀번호가 qwer1234 였음.
비밀번호 변경 api에서 12345678로 변경 -> 변경하기 전 비밀번호로 로그인하면 에러 발생
![image](https://github.com/user-attachments/assets/1c5feeb3-9667-4981-a292-d5652e28ea6b)

