### PR TITLE
[#55] Docs: 스웨거 명세서 작성

### DIFF
--- a/src/main/java/com/parentsgowork/server/web/controller/specification/EducationInfoSpecification.java
+++ b/src/main/java/com/parentsgowork/server/web/controller/specification/EducationInfoSpecification.java
@@ -16,6 +16,7 @@ public interface EducationInfoSpecification {
     @Operation(summary = "내가 저장한 교육정보 리스트 조회", description = "내가 저장한 교육정보 리스트를 조회합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BOOKMARK4001", description = "❌ 교육정보가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<List<EducationInfoResponseDTO.EducationInfoListDTO>> getEducationInfoList();
@@ -24,6 +25,7 @@ public interface EducationInfoSpecification {
     @Operation(summary = "특정 교육정보 조회", description = "내가 저장한 특정 교육정보를 조회합니다. 교육정보 아이디 값을 보내주세요.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BOOKMARK4001", description = "❌ 교육정보가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<EducationInfoResponseDTO.EducationInfoDetailDTO> getEducationInfoDetails(@PathVariable Long educationInfoId);
@@ -32,6 +34,7 @@ public interface EducationInfoSpecification {
     @Operation(summary = "내가 저장한 교육정보 삭제", description = "내가 저장한 특정 교육정보를 삭제합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BOOKMARK4001", description = "❌ 교육정보가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<EducationInfoResponseDTO.DeleteEducationInfoDTO> deleteEducationInfo(@PathVariable("educationInfoId") Long educationInfoId);

--- a/src/main/java/com/parentsgowork/server/web/controller/specification/JobInfoSpecification.java
+++ b/src/main/java/com/parentsgowork/server/web/controller/specification/JobInfoSpecification.java
@@ -38,6 +38,7 @@ public interface JobInfoSpecification {
     @Operation(summary = "내가 저장한 구직정보 리스트 조회", description = "내가 저장한 구직정보 리스트를 조회합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BOOKMARK4003", description = "❌ 구직정보가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<List<JobInfoResponseDTO.JobInfoListDTO>> getJobInfoList();
@@ -46,6 +47,7 @@ public interface JobInfoSpecification {
     @Operation(summary = "특정 구직정보 조회", description = "내가 저장한 특정 구직정보를 조회합니다. 구직정보 아이디 값을 보내주세요.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BOOKMARK4003", description = "❌ 구직정보가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<JobInfoResponseDTO.JobInfoDetailDTO> getJobInfoDetails(@PathVariable Long jobInfoId);
@@ -54,6 +56,7 @@ public interface JobInfoSpecification {
     @Operation(summary = "내가 저장한 구직정보 삭제", description = "내가 저장한 특정 구직정보를 삭제합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BOOKMARK4003", description = "❌ 구직정보가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<JobInfoResponseDTO.DeleteJobInfoDTO> deleteJobInfo(@PathVariable("jobInfoId") Long jobInfoId);

--- a/src/main/java/com/parentsgowork/server/web/controller/specification/PolicyInfoSpecification.java
+++ b/src/main/java/com/parentsgowork/server/web/controller/specification/PolicyInfoSpecification.java
@@ -18,6 +18,7 @@ public interface PolicyInfoSpecification {
     @Operation(summary = "내가 저장한 고용 정책/복지 리스트 조회", description = "내가 저장한 고용 정책/복지 리스트를 조회합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BOOKMARK4002", description = "❌ 고용 정책/복지 정보가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<List<PolicyInfoResponseDTO.PolicyInfoListDTO>> getPolicyInfoList();
@@ -26,6 +27,7 @@ public interface PolicyInfoSpecification {
     @Operation(summary = "특정 고용 정책/복지 조회", description = "내가 저장한 특정 고용 정책/복지를 조회합니다. 고용 정책/복지 아이디 값을 보내주세요.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BOOKMARK4002", description = "❌ 고용 정책/복지 정보가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<PolicyInfoResponseDTO.PolicyInfoDetailDTO> getPolicyInfoDetails(@PathVariable Long policyInfoId);
@@ -34,6 +36,7 @@ public interface PolicyInfoSpecification {
     @Operation(summary = "내가 저장한 고용 정책/복지 삭제", description = "내가 저장한 특정 고용 정책/복지를 삭제합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "⭕ SUCCESS, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BOOKMARK4002", description = "❌ 고용 정책/복지 정보가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "❌ BAD, 잘못된 요청", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     ApiResponse<PolicyInfoResponseDTO.DeletePolicyInfoDTO> deletePolicyInfo(@PathVariable("policyInfoId") Long policyInfoId);


### PR DESCRIPTION
## 📝 작업 내용
> 스웨거 명세서에 "정보가 존재하지 않습니다." 관련 응답코드 추가
이미 저장한 구직정보는 저장할 수 없게 에러처리하게 되면 ErrorStatus와 스웨거 명세서 업데이트 예정
(ex)
`@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "BOOKMARK4004", description = "❌ 이미 저장한 구직정보입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),`





## 🔍 테스트 방법
> x